### PR TITLE
delete facebook click tracking query and fix use hardcoded 'https://'…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ secret.ts
 web/build/
 web/assets/music/
 web/assets/data/tz*.json
+web/assets/scripts/
 server/build/
 server/gapi-key.json
 yarn-error.log

--- a/app.js
+++ b/app.js
@@ -32,6 +32,8 @@ const logger = () => {
 // sets x-frame-options header to disallow our content to be rendered in iframes.
 app.use(helmet());
 
+// only for dev
+// prod uses nginx to serve static files
 app.use('/static', express.static(path.join(__dirname, '/web/assets')));
 app.use('/static', express.static(path.join(__dirname, '/web/build')));
 
@@ -69,7 +71,8 @@ Object.keys(oldRoutesToRedirectsMap).forEach(key => (
 
 // We catch any route first, and then let our front-end routing do the work.
 app.get(/\//, async (req, res) => {
-    const { sanitize = '', notFound = false, ...meta } = await getMetaFromPathAndSanitize(req.url);
+    delete req.query.fbclid;
+    const { sanitize = '', notFound = false, ...meta } = await getMetaFromPathAndSanitize(req.path);
     if (notFound) {
         res.status(404);
     }
@@ -82,7 +85,7 @@ app.get(/\//, async (req, res) => {
         }
         res.render('index', {
             twitter: meta,
-            facebook: { ...meta, url: req.protocol + '://' + req.get('host') + req.originalUrl },
+            facebook: { ...meta, url: 'https://' + req.get('host') + req.originalUrl },
         });
     }
 });


### PR DESCRIPTION
… instead of previously req.protocol, because that will always be http since we're reverse proxy-ing